### PR TITLE
Refactor: Rename groups to tags

### DIFF
--- a/app/src/main/java/m2x/att/client/common/Constants.java
+++ b/app/src/main/java/m2x/att/client/common/Constants.java
@@ -10,7 +10,7 @@ public class Constants {
     //Device calls
     public static final String DEVICE_SEARCH_PUBLIC_CATALOG = API_BASE_URL.concat("/devices/catalog");
     public static final String DEVICE_SEARCH_CATALOG = API_BASE_URL.concat("/devices");
-    public static final String DEVICE_LIST_GROUPS = API_BASE_URL.concat("/devices/groups");
+    public static final String DEVICE_LIST_TAGS = API_BASE_URL.concat("/devices/tags");
     public static final String DEVICE_CREATE = API_BASE_URL.concat("/devices");
     public static final String DEVICE_UPDATE_DETAILS = API_BASE_URL.concat("/devices/%s");
     public static final String DEVICE_VIEW_DETAILS = API_BASE_URL.concat("/devices/%s");

--- a/app/src/main/java/m2x/att/client/model/Device.java
+++ b/app/src/main/java/m2x/att/client/model/Device.java
@@ -18,7 +18,7 @@ public class Device {
 
     public static final int REQUEST_CODE_SEARCH_PUBLIC_CATALOG = 1001;
     public static final int REQUEST_CODE_SEARCH_DEVICES = 1002;
-    public static final int REQUEST_CODE_LIST_DEVICE_GROUP = 1003;
+    public static final int REQUEST_CODE_LIST_DEVICE_TAG = 1003;
     public static final int REQUEST_CODE_CREATE_DEVICE = 1004;
     public static final int REQUEST_CODE_DEVICE_DETAILS = 1005;
     public static final int REQUEST_CODE_DEVICE_LOCATION = 1006;
@@ -63,13 +63,13 @@ public class Device {
         );
     }
 
-    public static final void listDeviceGroups(Context context, ResponseListener listener){
+    public static final void listDeviceTags(Context context, ResponseListener listener){
         JsonRequest.makeGetRequest(
                 context,
-                Constants.DEVICE_LIST_GROUPS,
+                Constants.DEVICE_LIST_TAGS,
                 null,
                 listener,
-                REQUEST_CODE_LIST_DEVICE_GROUP
+                REQUEST_CODE_LIST_DEVICE_TAG
         );
     }
 


### PR DESCRIPTION
The groups concept has been deprecated in favor of [tags](https://m2x.att.com/developer/documentation/v2/device#List-Device-Tags).

Add the necessary changes to this library to reflect that change.