### PR TITLE
Add Search Devices Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ To include the M2X Android Client Library in your project :
        }
     ```
 
-2. Add M2X Android Library as a dependency in module level `build.gradle` :
+2. Add M2X Android Library as a dependency in module level `build.gradle`, replacing "v.v.v" with the target version number for the M2X Android library :
     ```
     dependencies {
         ...
-        compile group: 'com.att.m2x', name: 'android', version: '3.0.0'
+        compile group: 'com.att.m2x', name: 'android', version: 'v.v.v'
         ...
     }
     ```
@@ -52,7 +52,7 @@ To include the M2X Android Client Library in your project :
 ### Manual Installation
 
 1. Obtain the `m2x-android-v.v.v.aar` for the [latest version](https://github.com/attm2x/m2x-android/releases/latest) of the M2X Android Client Library and place it in your project's `/libs` directory (if no `/libs` directory is present, create it).
-2. Add the following to your projects top level `build.gradle` :
+2. Add the following to your projects top level `build.gradle`, replacing "v.v.v" with the target version number for the M2X Android library :
     ```
       repositories {
           flatDir {
@@ -62,7 +62,7 @@ To include the M2X Android Client Library in your project :
     
       dependencies {
           compile fileTree(dir: 'libs', include: ['*.jar'])
-          compile 'com.att.m2x.android:m2x-android:3.0.0@aar'
+          compile 'com.att.m2x.android:m2x-android:v.v.v@aar'
           compile 'com.mcxiaoke.volley:library:1.0.9'
           compile 'com.google.code.gson:gson:2.3.1'
       }
@@ -175,7 +175,9 @@ The call only needs a context and if a call was made the SDK will return the las
 
 Refer to the documentation on each class for further usage instructions.
 
-## Example
+## Examples
+
+### Update Device
 
 In order to run this example, you will need a `Device ID`. If you don't have any, access your M2X account, create a new [Device](https://m2x.att.com/devices), and copy the `Device ID`.
 
@@ -190,6 +192,36 @@ This call updates the device location:
             "  \"timestamp\": \"" + DateUtils.dateTimeToString(new Date()) + "\",\n" +
             "  \"elevation\": 5 }");
         Device.updateDeviceLocation(getApplicationContext(), obj, deviceID, new ResponseListener() {
+            @Override
+            public void onRequestCompleted(ApiV2Response apiV2Response, int i) {
+                // Handle Success
+            }
+
+            @Override
+            public void onRequestError(ApiV2Response apiV2Response, int i) {
+                // Handle Error
+            }
+        });
+    } catch (JSONException e) {
+            e.printStackTrace();
+    }
+```
+
+### Search Devices
+
+The [Search Devices](https://m2x.att.com/developer/documentation/v2/device#Search-Devices) endpoint
+accepts a variety of search filters, such as `ids` or `tags`, via the URL query string. However,
+some more complex search filters must be requested via a JSON body, such as `streams` and `metadata`.
+
+The following example shows how to perform a Device search by passing search filters via both query
+string parameters and JSON body.
+
+```Java
+    try {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("name", "name-to-query");
+        JSONObject body = new JSONObject("{ \"streams\": { \"stream-id\": { \"gt\": 50 } } }");
+        Device.searchDevices(getApplicationContext(), params, body, new ResponseListener() {
             @Override
             public void onRequestCompleted(ApiV2Response apiV2Response, int i) {
                 // Handle Success

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ string parameters and JSON body.
 ```Java
     try {
         HashMap<String, String> params = new HashMap<>();
-        params.put("name", "name-to-query");
-        JSONObject body = new JSONObject("{ \"streams\": { \"stream-id\": { \"gt\": 50 } } }");
+        params.put("[param-name]", "[query]");
+        JSONObject body = new JSONObject("{ \"[param-object]\": { \"[key]\": \"[value]\" } }");
         Device.searchDevices(getApplicationContext(), params, body, new ResponseListener() {
             @Override
             public void onRequestCompleted(ApiV2Response apiV2Response, int i) {

--- a/app/src/main/java/com/att/m2x/android/common/Constants.java
+++ b/app/src/main/java/com/att/m2x/android/common/Constants.java
@@ -14,7 +14,8 @@ public class Constants {
 
     //Device calls
     public static final String DEVICE_SEARCH_PUBLIC_CATALOG = API_BASE_URL.concat("/devices/catalog");
-    public static final String DEVICE_SEARCH_CATALOG = API_BASE_URL.concat("/devices");
+    public static final String DEVICE_LIST = API_BASE_URL.concat("/devices");
+    public static final String DEVICE_SEARCH = API_BASE_URL.concat("/devices/search");
     public static final String DEVICE_LIST_TAGS = API_BASE_URL.concat("/devices/tags");
     public static final String DEVICE_CREATE = API_BASE_URL.concat("/devices");
     public static final String DEVICE_UPDATE_DETAILS = API_BASE_URL.concat("/devices/%s");

--- a/app/src/main/java/com/att/m2x/android/model/Device.java
+++ b/app/src/main/java/com/att/m2x/android/model/Device.java
@@ -36,6 +36,7 @@ public class Device {
     public static final int REQUEST_CODE_DEVICE_POST_DEVICE_UPDATES = 1018;
     public static final int REQUEST_CODE_DEVICE_VIEW_REQUEST_LOG = 1025;
     public static final int REQUEST_CODE_DEVICE_DELETE = 1026;
+    public static final int REQUEST_CODE_LIST_DEVICES = 1027;
 
     public static final void searchPublicCatalog(Context context,HashMap<String,String> params, ResponseListener listener){
         JsonRequest.makeGetRequest(
@@ -47,11 +48,22 @@ public class Device {
         );
     }
 
-    public static final void searchDevices(Context context,HashMap<String,String> params, ResponseListener listener){
+    public static final void listDevices(Context context, HashMap<String,String> params, ResponseListener listener){
         JsonRequest.makeGetRequest(
                 context,
-                Constants.DEVICE_SEARCH_CATALOG,
+                Constants.DEVICE_LIST,
                 params,
+                listener,
+                REQUEST_CODE_LIST_DEVICES
+        );
+    }
+
+    public static final void searchDevices(Context context, HashMap<String,String> params, JSONObject body, ResponseListener listener){
+        JsonRequest.makeGetRequest(
+                context,
+                Constants.DEVICE_SEARCH,
+                params,
+                body,
                 listener,
                 REQUEST_CODE_SEARCH_DEVICES
         );

--- a/app/src/main/java/com/att/m2x/android/network/JsonRequest.java
+++ b/app/src/main/java/com/att/m2x/android/network/JsonRequest.java
@@ -109,6 +109,48 @@ public class JsonRequest {
         VolleyResourcesSingleton.getInstance(context.getApplicationContext()).addToRequestQueue(jsonObjReq);
     }
 
+    public static void makeGetRequest(final Context context,
+                                      String url,
+                                      HashMap<String,String> params,
+                                      JSONObject body,
+                                      final ResponseListener listener,
+                                      final int requestCode) {
+
+        if(params!=null)
+            url = url.concat("?".concat(ArrayUtils.mapToQueryString(params)));
+
+        JsonObjectRequest jsonObjReq = new JsonObjectRequest(
+                Request.Method.GET,
+                url,
+                body,
+                new Response.Listener<JSONObject>() {
+                    @Override
+                    public void onResponse(JSONObject o) {
+                        handleResponse(context, listener, requestCode, o);
+                    }
+                },
+                new Response.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        handleError(context, listener, requestCode, error);
+                    }
+                })
+        {
+            @Override
+            public Map<String, String> getHeaders() throws AuthFailureError {
+                return JsonRequest.getHeaders(context);
+            }
+
+            @Override
+            protected Response<JSONObject> parseNetworkResponse(NetworkResponse response) {
+                return JsonRequest.parseNetworkResponse(response);
+            }
+        };
+
+        //It's better if the queue is obtained with an app context to keep it alive while the app is in foreground.
+        VolleyResourcesSingleton.getInstance(context.getApplicationContext()).addToRequestQueue(jsonObjReq);
+    }
+
     public static void makePutRequest(final Context context,
                                       String url,
                                       JSONObject params,


### PR DESCRIPTION
Add support for the [Search Devices endpoint](https://m2x.att.com/developer/documentation/v2/device#Search-Devices). Searching devices was previously done via the List Devices endpoint `/devices`, but now has it's own dedicated endpoint `/devices/search`. 

This issue has two parts:

1. Update the documentation for List Devices
2. Add support for Search Devices

Example of this update in the Ruby library: https://github.com/attm2x/m2x-ruby/commit/20e563d31e13dbca8771d10f856935dab7ee33cc