### PR TITLE
Add Support for Device/Distribution Metadata Endpoints

### DIFF
--- a/app/src/main/java/com/att/m2x/android/common/Constants.java
+++ b/app/src/main/java/com/att/m2x/android/common/Constants.java
@@ -12,58 +12,65 @@ public class Constants {
                                             concat(android.os.Build.VERSION.RELEASE).
                                             concat(")");
 
-    //Device calls
-    public static final String DEVICE_SEARCH_PUBLIC_CATALOG = API_BASE_URL.concat("/devices/catalog");
-    public static final String DEVICE_LIST = API_BASE_URL.concat("/devices");
-    public static final String DEVICE_SEARCH = API_BASE_URL.concat("/devices/search");
-    public static final String DEVICE_LIST_TAGS = API_BASE_URL.concat("/devices/tags");
-    public static final String DEVICE_CREATE = API_BASE_URL.concat("/devices");
-    public static final String DEVICE_UPDATE_DETAILS = API_BASE_URL.concat("/devices/%s");
-    public static final String DEVICE_VIEW_DETAILS = API_BASE_URL.concat("/devices/%s");
-    public static final String DEVICE_READ_LOCATION = API_BASE_URL.concat("/devices/%s/location");
-    public static final String DEVICE_UPDATE_LOCATION = API_BASE_URL.concat("/devices/%s/location");
-    public static final String DEVICE_LIST_DATA_STREAMS = API_BASE_URL.concat("/devices/%s/streams");
-    public static final String DEVICE_CREATE_UPDATE_DATA_STREAMS = API_BASE_URL.concat("/devices/%s/streams/%s");
-    public static final String DEVICE_UPDATE_DATA_STREAM_VALUE = API_BASE_URL.concat("/devices/%s/streams/%s/value");
-    public static final String DEVICE_VIEW_DATA_STREAM = API_BASE_URL.concat("/devices/%s/streams/%s");
-    public static final String DEVICE_LIST_DATA_STREAM_VALUES = API_BASE_URL.concat("/devices/%s/streams/%s/values");
-    public static final String DEVICE_LIST_DATA_STREAM_SAMPLING = API_BASE_URL.concat("/devices/%s/streams/%s/sampling");
-    public static final String DEVICE_LIST_DATA_STREAM_STATS = API_BASE_URL.concat("/devices/%s/streams/%s/stats");
-    public static final String DEVICE_POST_DATA_STREAM_VALUES = API_BASE_URL.concat("/devices/%s/streams/%s/values");
-    public static final String DEVICE_DELETE_DATA_STREAM_VALUES = API_BASE_URL.concat("/devices/%s/streams/%s/values");
-    public static final String DEVICE_DELETE_DATA_STREAM = API_BASE_URL.concat("/devices/%s/streams/%s");
-    public static final String DEVICE_POST_UPDATES = API_BASE_URL.concat("/devices/%s/updates");
-    public static final String DEVICE_REQUEST_LOG = API_BASE_URL.concat("/devices/%s/log");
-    public static final String DEVICE_DELETE = API_BASE_URL.concat("/devices/%s");
+    //Device
+    public static final String DEVICE_PATH = "/devices";
+    public static final String DEVICE_SEARCH_PUBLIC_CATALOG = DEVICE_PATH.concat("/catalog");
+    public static final String DEVICE_LIST = DEVICE_PATH;
+    public static final String DEVICE_SEARCH = DEVICE_PATH.concat("/search");
+    public static final String DEVICE_LIST_TAGS = DEVICE_PATH.concat("/tags");
+    public static final String DEVICE_CREATE = DEVICE_PATH;
+    public static final String DEVICE_UPDATE_DETAILS = DEVICE_PATH.concat("/%s");
+    public static final String DEVICE_VIEW_DETAILS = DEVICE_PATH.concat("/%s");
+    public static final String DEVICE_READ_LOCATION = DEVICE_PATH.concat("/%s/location");
+    public static final String DEVICE_UPDATE_LOCATION = DEVICE_PATH.concat("/%s/location");
+    public static final String DEVICE_METADATA = DEVICE_PATH.concat("/%s/metadata");
+    public static final String DEVICE_METADATA_FIELD = DEVICE_PATH.concat("/%s/metadata/%s");
+    public static final String DEVICE_LIST_DATA_STREAMS = DEVICE_PATH.concat("/%s/streams");
+    public static final String DEVICE_CREATE_UPDATE_DATA_STREAMS = DEVICE_PATH.concat("/%s/streams/%s");
+    public static final String DEVICE_UPDATE_DATA_STREAM_VALUE = DEVICE_PATH.concat("/%s/streams/%s/value");
+    public static final String DEVICE_VIEW_DATA_STREAM = DEVICE_PATH.concat("/%s/streams/%s");
+    public static final String DEVICE_LIST_DATA_STREAM_VALUES = DEVICE_PATH.concat("/%s/streams/%s/values");
+    public static final String DEVICE_LIST_DATA_STREAM_SAMPLING = DEVICE_PATH.concat("/%s/streams/%s/sampling");
+    public static final String DEVICE_LIST_DATA_STREAM_STATS = DEVICE_PATH.concat("/%s/streams/%s/stats");
+    public static final String DEVICE_POST_DATA_STREAM_VALUES = DEVICE_PATH.concat("/%s/streams/%s/values");
+    public static final String DEVICE_DELETE_DATA_STREAM_VALUES = DEVICE_PATH.concat("/%s/streams/%s/values");
+    public static final String DEVICE_DELETE_DATA_STREAM = DEVICE_PATH.concat("/%s/streams/%s");
+    public static final String DEVICE_POST_UPDATES = DEVICE_PATH.concat("/%s/updates");
+    public static final String DEVICE_REQUEST_LOG = DEVICE_PATH.concat("/%s/log");
+    public static final String DEVICE_DELETE = DEVICE_PATH.concat("/%s");
 
     //Distribution
-    public static final String DISTRIBUTION_LIST = API_BASE_URL.concat("/distributions");
-    public static final String DISTRIBUTION_CREATE = API_BASE_URL.concat("/distributions");
-    public static final String DISTRIBUTION_VIEW_DETAILS = API_BASE_URL.concat("/distributions/%s");
-    public static final String DISTRIBUTION_UPDATE_DETAILS = API_BASE_URL.concat("/distributions/%s");
-    public static final String DISTRIBUTION_LIST_DEVICES = API_BASE_URL.concat("/distributions/%s/devices");
-    public static final String DISTRIBUTION_ADD_DEVICE = API_BASE_URL.concat("/distributions/%s/devices");
-    public static final String DISTRIBUTION_DELETE = API_BASE_URL.concat("/distributions/%s");
-    public static final String DISTRIBUTION_LIST_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams");
-    public static final String DISTRIBUTION_CREATE_UPDATE_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams/%s");
-    public static final String DISTRIBUTION_VIEW_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams/%s");
-    public static final String DISTRIBUTION_DELETE_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams/%s");
+    public static final String DISTRIBUTION_PATH = "/distributions";
+    public static final String DISTRIBUTION_LIST = DISTRIBUTION_PATH;
+    public static final String DISTRIBUTION_CREATE = DISTRIBUTION_PATH;
+    public static final String DISTRIBUTION_VIEW_DETAILS = DISTRIBUTION_PATH.concat("/%s");
+    public static final String DISTRIBUTION_UPDATE_DETAILS = DISTRIBUTION_PATH.concat("/%s");
+    public static final String DISTRIBUTION_METADATA = DISTRIBUTION_PATH.concat("/%s/metadata");
+    public static final String DISTRIBUTION_METADATA_FIELD = DISTRIBUTION_PATH.concat("/%s/metadata/%s");
+    public static final String DISTRIBUTION_LIST_DEVICES = DISTRIBUTION_PATH.concat("/%s/devices");
+    public static final String DISTRIBUTION_ADD_DEVICE = DISTRIBUTION_PATH.concat("/%s/devices");
+    public static final String DISTRIBUTION_DELETE = DISTRIBUTION_PATH.concat("/%s");
+    public static final String DISTRIBUTION_LIST_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams");
+    public static final String DISTRIBUTION_CREATE_UPDATE_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams/%s");
+    public static final String DISTRIBUTION_VIEW_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams/%s");
+    public static final String DISTRIBUTION_DELETE_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams/%s");
 
     //Keys
-    public static final String KEYS_LIST = API_BASE_URL.concat("/keys");
-    public static final String KEYS_CREATE = API_BASE_URL.concat("/keys");
-    public static final String KEYS_DETAIL = API_BASE_URL.concat("/keys/%s");
-    public static final String KEYS_UPDATE = API_BASE_URL.concat("/keys/%s");
-    public static final String KEYS_REGENERATE = API_BASE_URL.concat("/keys/%s/regenerate");
-    public static final String KEYS_DELETE = API_BASE_URL.concat("/keys/%s");
+    public static final String KEYS_PATH = "/keys";
+    public static final String KEYS_LIST = KEYS_PATH;
+    public static final String KEYS_CREATE = KEYS_PATH;
+    public static final String KEYS_DETAIL = KEYS_PATH.concat("/%s");
+    public static final String KEYS_UPDATE = KEYS_PATH.concat("/%s");
+    public static final String KEYS_REGENERATE = KEYS_PATH.concat("/%s/regenerate");
+    public static final String KEYS_DELETE = KEYS_PATH.concat("/%s");
 
     //Charts
-    public static final String CHARTS_LIST = API_BASE_URL.concat("/charts");
-    public static final String CHARTS_CREATE = API_BASE_URL.concat("/charts");
-    public static final String CHARTS_VIEW_DETAILS = API_BASE_URL.concat("/charts/%s");
-    public static final String CHARTS_UPDATE = API_BASE_URL.concat("/charts/%s");
-    public static final String CHARTS_DELETE = API_BASE_URL.concat("/charts/%s");
-    public static final String CHARTS_RENDER = API_BASE_URL.concat("/charts/%s.%s");
-
+    public static final String CHARTS_PATH = "/charts";
+    public static final String CHARTS_LIST = CHARTS_PATH;
+    public static final String CHARTS_CREATE = CHARTS_PATH;
+    public static final String CHARTS_VIEW_DETAILS = CHARTS_PATH.concat("/%s");
+    public static final String CHARTS_UPDATE = CHARTS_PATH.concat("/%s");
+    public static final String CHARTS_DELETE = CHARTS_PATH.concat("/%s");
+    public static final String CHARTS_RENDER = CHARTS_PATH.concat("/%s.%s");
 
 }

--- a/app/src/main/java/com/att/m2x/android/common/Constants.java
+++ b/app/src/main/java/com/att/m2x/android/common/Constants.java
@@ -12,65 +12,62 @@ public class Constants {
                                             concat(android.os.Build.VERSION.RELEASE).
                                             concat(")");
 
-    //Device
-    public static final String DEVICE_PATH = "/devices";
-    public static final String DEVICE_SEARCH_PUBLIC_CATALOG = DEVICE_PATH.concat("/catalog");
-    public static final String DEVICE_LIST = DEVICE_PATH;
-    public static final String DEVICE_SEARCH = DEVICE_PATH.concat("/search");
-    public static final String DEVICE_LIST_TAGS = DEVICE_PATH.concat("/tags");
-    public static final String DEVICE_CREATE = DEVICE_PATH;
-    public static final String DEVICE_UPDATE_DETAILS = DEVICE_PATH.concat("/%s");
-    public static final String DEVICE_VIEW_DETAILS = DEVICE_PATH.concat("/%s");
-    public static final String DEVICE_READ_LOCATION = DEVICE_PATH.concat("/%s/location");
-    public static final String DEVICE_UPDATE_LOCATION = DEVICE_PATH.concat("/%s/location");
-    public static final String DEVICE_METADATA = DEVICE_PATH.concat("/%s/metadata");
-    public static final String DEVICE_METADATA_FIELD = DEVICE_PATH.concat("/%s/metadata/%s");
-    public static final String DEVICE_LIST_DATA_STREAMS = DEVICE_PATH.concat("/%s/streams");
-    public static final String DEVICE_CREATE_UPDATE_DATA_STREAMS = DEVICE_PATH.concat("/%s/streams/%s");
-    public static final String DEVICE_UPDATE_DATA_STREAM_VALUE = DEVICE_PATH.concat("/%s/streams/%s/value");
-    public static final String DEVICE_VIEW_DATA_STREAM = DEVICE_PATH.concat("/%s/streams/%s");
-    public static final String DEVICE_LIST_DATA_STREAM_VALUES = DEVICE_PATH.concat("/%s/streams/%s/values");
-    public static final String DEVICE_LIST_DATA_STREAM_SAMPLING = DEVICE_PATH.concat("/%s/streams/%s/sampling");
-    public static final String DEVICE_LIST_DATA_STREAM_STATS = DEVICE_PATH.concat("/%s/streams/%s/stats");
-    public static final String DEVICE_POST_DATA_STREAM_VALUES = DEVICE_PATH.concat("/%s/streams/%s/values");
-    public static final String DEVICE_DELETE_DATA_STREAM_VALUES = DEVICE_PATH.concat("/%s/streams/%s/values");
-    public static final String DEVICE_DELETE_DATA_STREAM = DEVICE_PATH.concat("/%s/streams/%s");
-    public static final String DEVICE_POST_UPDATES = DEVICE_PATH.concat("/%s/updates");
-    public static final String DEVICE_REQUEST_LOG = DEVICE_PATH.concat("/%s/log");
-    public static final String DEVICE_DELETE = DEVICE_PATH.concat("/%s");
+    //Device calls
+    public static final String DEVICE_SEARCH_PUBLIC_CATALOG = API_BASE_URL.concat("/devices/catalog");
+    public static final String DEVICE_LIST = API_BASE_URL.concat("/devices");
+    public static final String DEVICE_SEARCH = API_BASE_URL.concat("/devices/search");
+    public static final String DEVICE_LIST_TAGS = API_BASE_URL.concat("/devices/tags");
+    public static final String DEVICE_CREATE = API_BASE_URL.concat("/devices");
+    public static final String DEVICE_UPDATE_DETAILS = API_BASE_URL.concat("/devices/%s");
+    public static final String DEVICE_VIEW_DETAILS = API_BASE_URL.concat("/devices/%s");
+    public static final String DEVICE_READ_LOCATION = API_BASE_URL.concat("/devices/%s/location");
+    public static final String DEVICE_UPDATE_LOCATION = API_BASE_URL.concat("/devices/%s/location");
+    public static final String DEVICE_METADATA = API_BASE_URL.concat("/devices/%s/metadata");
+    public static final String DEVICE_METADATA_FIELD = API_BASE_URL.concat("/devices/%s/metadata/%s");
+    public static final String DEVICE_LIST_DATA_STREAMS = API_BASE_URL.concat("/devices/%s/streams");
+    public static final String DEVICE_CREATE_UPDATE_DATA_STREAMS = API_BASE_URL.concat("/devices/%s/streams/%s");
+    public static final String DEVICE_UPDATE_DATA_STREAM_VALUE = API_BASE_URL.concat("/devices/%s/streams/%s/value");
+    public static final String DEVICE_VIEW_DATA_STREAM = API_BASE_URL.concat("/devices/%s/streams/%s");
+    public static final String DEVICE_LIST_DATA_STREAM_VALUES = API_BASE_URL.concat("/devices/%s/streams/%s/values");
+    public static final String DEVICE_LIST_DATA_STREAM_SAMPLING = API_BASE_URL.concat("/devices/%s/streams/%s/sampling");
+    public static final String DEVICE_LIST_DATA_STREAM_STATS = API_BASE_URL.concat("/devices/%s/streams/%s/stats");
+    public static final String DEVICE_POST_DATA_STREAM_VALUES = API_BASE_URL.concat("/devices/%s/streams/%s/values");
+    public static final String DEVICE_DELETE_DATA_STREAM_VALUES = API_BASE_URL.concat("/devices/%s/streams/%s/values");
+    public static final String DEVICE_DELETE_DATA_STREAM = API_BASE_URL.concat("/devices/%s/streams/%s");
+    public static final String DEVICE_POST_UPDATES = API_BASE_URL.concat("/devices/%s/updates");
+    public static final String DEVICE_REQUEST_LOG = API_BASE_URL.concat("/devices/%s/log");
+    public static final String DEVICE_DELETE = API_BASE_URL.concat("/devices/%s");
 
     //Distribution
-    public static final String DISTRIBUTION_PATH = "/distributions";
-    public static final String DISTRIBUTION_LIST = DISTRIBUTION_PATH;
-    public static final String DISTRIBUTION_CREATE = DISTRIBUTION_PATH;
-    public static final String DISTRIBUTION_VIEW_DETAILS = DISTRIBUTION_PATH.concat("/%s");
-    public static final String DISTRIBUTION_UPDATE_DETAILS = DISTRIBUTION_PATH.concat("/%s");
-    public static final String DISTRIBUTION_METADATA = DISTRIBUTION_PATH.concat("/%s/metadata");
-    public static final String DISTRIBUTION_METADATA_FIELD = DISTRIBUTION_PATH.concat("/%s/metadata/%s");
-    public static final String DISTRIBUTION_LIST_DEVICES = DISTRIBUTION_PATH.concat("/%s/devices");
-    public static final String DISTRIBUTION_ADD_DEVICE = DISTRIBUTION_PATH.concat("/%s/devices");
-    public static final String DISTRIBUTION_DELETE = DISTRIBUTION_PATH.concat("/%s");
-    public static final String DISTRIBUTION_LIST_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams");
-    public static final String DISTRIBUTION_CREATE_UPDATE_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams/%s");
-    public static final String DISTRIBUTION_VIEW_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams/%s");
-    public static final String DISTRIBUTION_DELETE_DATA_STREAMS = DISTRIBUTION_PATH.concat("/%s/streams/%s");
+    public static final String DISTRIBUTION_LIST = API_BASE_URL.concat("/distributions");
+    public static final String DISTRIBUTION_CREATE = API_BASE_URL.concat("/distributions");
+    public static final String DISTRIBUTION_VIEW_DETAILS = API_BASE_URL.concat("/distributions/%s");
+    public static final String DISTRIBUTION_UPDATE_DETAILS = API_BASE_URL.concat("/distributions/%s");
+    public static final String DISTRIBUTION_METADATA = API_BASE_URL.concat("/distributions/%s/metadata");
+    public static final String DISTRIBUTION_METADATA_FIELD = API_BASE_URL.concat("/distributions/%s/metadata/%s");
+    public static final String DISTRIBUTION_LIST_DEVICES = API_BASE_URL.concat("/distributions/%s/devices");
+    public static final String DISTRIBUTION_ADD_DEVICE = API_BASE_URL.concat("/distributions/%s/devices");
+    public static final String DISTRIBUTION_DELETE = API_BASE_URL.concat("/distributions/%s");
+    public static final String DISTRIBUTION_LIST_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams");
+    public static final String DISTRIBUTION_CREATE_UPDATE_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams/%s");
+    public static final String DISTRIBUTION_VIEW_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams/%s");
+    public static final String DISTRIBUTION_DELETE_DATA_STREAMS = API_BASE_URL.concat("/distributions/%s/streams/%s");
 
     //Keys
-    public static final String KEYS_PATH = "/keys";
-    public static final String KEYS_LIST = KEYS_PATH;
-    public static final String KEYS_CREATE = KEYS_PATH;
-    public static final String KEYS_DETAIL = KEYS_PATH.concat("/%s");
-    public static final String KEYS_UPDATE = KEYS_PATH.concat("/%s");
-    public static final String KEYS_REGENERATE = KEYS_PATH.concat("/%s/regenerate");
-    public static final String KEYS_DELETE = KEYS_PATH.concat("/%s");
+    public static final String KEYS_LIST = API_BASE_URL.concat("/keys");
+    public static final String KEYS_CREATE = API_BASE_URL.concat("/keys");
+    public static final String KEYS_DETAIL = API_BASE_URL.concat("/keys/%s");
+    public static final String KEYS_UPDATE = API_BASE_URL.concat("/keys/%s");
+    public static final String KEYS_REGENERATE = API_BASE_URL.concat("/keys/%s/regenerate");
+    public static final String KEYS_DELETE = API_BASE_URL.concat("/keys/%s");
 
     //Charts
-    public static final String CHARTS_PATH = "/charts";
-    public static final String CHARTS_LIST = CHARTS_PATH;
-    public static final String CHARTS_CREATE = CHARTS_PATH;
-    public static final String CHARTS_VIEW_DETAILS = CHARTS_PATH.concat("/%s");
-    public static final String CHARTS_UPDATE = CHARTS_PATH.concat("/%s");
-    public static final String CHARTS_DELETE = CHARTS_PATH.concat("/%s");
-    public static final String CHARTS_RENDER = CHARTS_PATH.concat("/%s.%s");
+    public static final String CHARTS_LIST = API_BASE_URL.concat("/charts");
+    public static final String CHARTS_CREATE = API_BASE_URL.concat("/charts");
+    public static final String CHARTS_VIEW_DETAILS = API_BASE_URL.concat("/charts/%s");
+    public static final String CHARTS_UPDATE = API_BASE_URL.concat("/charts/%s");
+    public static final String CHARTS_DELETE = API_BASE_URL.concat("/charts/%s");
+    public static final String CHARTS_RENDER = API_BASE_URL.concat("/charts/%s.%s");
+
 
 }

--- a/app/src/main/java/com/att/m2x/android/common/Constants.java
+++ b/app/src/main/java/com/att/m2x/android/common/Constants.java
@@ -69,5 +69,4 @@ public class Constants {
     public static final String CHARTS_DELETE = API_BASE_URL.concat("/charts/%s");
     public static final String CHARTS_RENDER = API_BASE_URL.concat("/charts/%s.%s");
 
-
 }

--- a/app/src/main/java/com/att/m2x/android/model/Device.java
+++ b/app/src/main/java/com/att/m2x/android/model/Device.java
@@ -37,6 +37,10 @@ public class Device {
     public static final int REQUEST_CODE_DEVICE_VIEW_REQUEST_LOG = 1025;
     public static final int REQUEST_CODE_DEVICE_DELETE = 1026;
     public static final int REQUEST_CODE_LIST_DEVICES = 1027;
+    public static final int REQUEST_CODE_METADATA = 1028;
+    public static final int REQUEST_CODE_UPDATE_METADATA = 1029;
+    public static final int REQUEST_CODE_METADATA_FIELD = 1030;
+    public static final int REQUEST_CODE_UPDATE_METADATA_FIELD = 1031;
 
     public static final void searchPublicCatalog(Context context,HashMap<String,String> params, ResponseListener listener){
         JsonRequest.makeGetRequest(
@@ -127,6 +131,40 @@ public class Device {
                 listener,
                 REQUEST_CODE_DEVICE_UPDATE_LOCATION
         );
+    }
+
+    public static final void metadata(Context context, String deviceId, ResponseListener listener){
+        Metadata.metadata(
+                context,
+                String.format(Locale.US, Constants.DEVICE_METADATA, deviceId),
+                listener,
+                REQUEST_CODE_METADATA);
+    }
+
+    public static final void updateMetadata(Context context, String deviceId, JSONObject body, ResponseListener listener){
+        Metadata.updateMetadata(
+                context,
+                String.format(Locale.US, Constants.DEVICE_METADATA, deviceId),
+                body,
+                listener,
+                REQUEST_CODE_UPDATE_METADATA);
+    }
+
+    public static final void metadataField(Context context, String deviceId, String field, ResponseListener listener){
+        Metadata.metadataField(
+                context,
+                String.format(Locale.US, Constants.DEVICE_METADATA_FIELD, deviceId, field),
+                listener,
+                REQUEST_CODE_METADATA_FIELD);
+    }
+
+    public static final void updateMetadataField(Context context, String deviceId, String field, JSONObject body, ResponseListener listener){
+        Metadata.updateMetadataField(
+                context,
+                String.format(Locale.US, Constants.DEVICE_METADATA_FIELD, deviceId, field),
+                body,
+                listener,
+                REQUEST_CODE_UPDATE_METADATA_FIELD);
     }
 
     public static final void listDataStreams(Context context,String deviceId, ResponseListener listener){

--- a/app/src/main/java/com/att/m2x/android/model/Distribution.java
+++ b/app/src/main/java/com/att/m2x/android/model/Distribution.java
@@ -26,6 +26,10 @@ public class Distribution {
     public static final int REQUEST_CODE_CREATE_UPDATE_DATA_STREAMS = 2008;
     public static final int REQUEST_CODE_VIEW_DATA_STREAM = 2009;
     public static final int REQUEST_CODE_DELETE_DATA_STREAM = 2010;
+    public static final int REQUEST_CODE_METADATA = 2011;
+    public static final int REQUEST_CODE_UPDATE_METADATA = 2012;
+    public static final int REQUEST_CODE_METADATA_FIELD = 2013;
+    public static final int REQUEST_CODE_UPDATE_METADATA_FIELD = 2014;
 
     public static final void list(Context context, ResponseListener listener){
         JsonRequest.makeGetRequest(
@@ -65,6 +69,40 @@ public class Distribution {
                 listener,
                 REQUEST_CODE_UPDATE_DISTRIBUTION_DETAILS
         );
+    }
+
+    public static final void metadata(Context context, String deviceId, ResponseListener listener){
+        Metadata.metadata(
+                context,
+                String.format(Locale.US, Constants.DISTRIBUTION_METADATA, deviceId),
+                listener,
+                REQUEST_CODE_METADATA);
+    }
+
+    public static final void updateMetadata(Context context, String deviceId, JSONObject body, ResponseListener listener){
+        Metadata.updateMetadata(
+                context,
+                String.format(Locale.US, Constants.DISTRIBUTION_METADATA, deviceId),
+                body,
+                listener,
+                REQUEST_CODE_UPDATE_METADATA);
+    }
+
+    public static final void metadataField(Context context, String deviceId, String field, ResponseListener listener){
+        Metadata.metadataField(
+                context,
+                String.format(Locale.US, Constants.DISTRIBUTION_METADATA_FIELD, deviceId, field),
+                listener,
+                REQUEST_CODE_METADATA_FIELD);
+    }
+
+    public static final void updateMetadataField(Context context, String deviceId, String field, JSONObject body, ResponseListener listener){
+        Metadata.updateMetadataField(
+                context,
+                String.format(Locale.US, Constants.DISTRIBUTION_METADATA_FIELD, deviceId, field),
+                body,
+                listener,
+                REQUEST_CODE_UPDATE_METADATA_FIELD);
     }
 
     public static final void listDevices(Context context,String distributionId, ResponseListener listener){

--- a/app/src/main/java/com/att/m2x/android/model/Metadata.java
+++ b/app/src/main/java/com/att/m2x/android/model/Metadata.java
@@ -1,0 +1,61 @@
+package com.att.m2x.android.model;
+
+import android.content.Context;
+
+import com.att.m2x.android.listeners.ResponseListener;
+import com.att.m2x.android.network.JsonRequest;
+
+import org.json.JSONObject;
+
+/**
+ * Created by kristinpeterson on 12/26/15.
+ */
+public class Metadata {
+
+    /**
+     * Get custom metadata of an existing entity.
+     *
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata">https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata">https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata">https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata</a>
+     */
+    public static final void metadata(Context context, String path, ResponseListener listener, int requestCode) {
+        JsonRequest.makeGetRequest(context, path, null, listener, requestCode);
+    }
+
+    /**
+     * Update the custom metadata of the specified entity.
+     *
+     * @param body parameters for the request as JSON object
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata">https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata">https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata">https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata</a>
+     */
+    public static final void updateMetadata(Context context, String path, JSONObject body, ResponseListener listener, int requestCode) {
+        JsonRequest.makePutRequest(context, path, body, listener, requestCode);
+    }
+
+    /**
+     * Get the value of a single custom metadata field from an existing entity.
+     *
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata-Field">https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata-Field</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata-Field">https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata-Field</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata-Field">https://m2x.att.com/developer/documentation/v2/collections#Read-Collection-Metadata-Field</a>
+     */
+    public static final void metadataField(Context context, String path, ResponseListener listener, int requestCode) {
+        JsonRequest.makeGetRequest(context, path, null, listener, requestCode);
+    }
+
+    /**
+     * Update the custom metadata of the specified entity.
+     *
+     * @param body parameters for the request as JSON object
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata-Field">https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata-Field</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata-Field">https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata-Field</a>
+     * @see <a href="https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata-Field">https://m2x.att.com/developer/documentation/v2/collections#Update-Collection-Metadata-Field</a>
+     */
+    public static final void updateMetadataField(Context context, String path, JSONObject body, ResponseListener listener, int requestCode) {
+        JsonRequest.makePutRequest(context, path, body, listener, requestCode);
+    }
+
+}

--- a/app/src/main/java/com/att/m2x/android/network/JsonRequest.java
+++ b/app/src/main/java/com/att/m2x/android/network/JsonRequest.java
@@ -31,54 +31,55 @@ public class JsonRequest {
     final static ApiV2Response apiResponse = new ApiV2Response();
 
     public static void makePostRequest(final Context context,
-                                       String url,
+                                       String path,
                                        JSONObject body,
                                        final ResponseListener listener,
                                        final int requestCode) {
-        makeRequest(context, Request.Method.POST, url, null, body, listener, requestCode);
+        makeRequest(context, Request.Method.POST, path, null, body, listener, requestCode);
     }
 
     public static void makeGetRequest(final Context context,
-                                      String url,
+                                      String path,
                                       HashMap<String,String> params,
                                       final ResponseListener listener,
                                       final int requestCode) {
-        makeRequest(context, Request.Method.GET, url, params, null, listener, requestCode);
+        makeRequest(context, Request.Method.GET, path, params, null, listener, requestCode);
     }
 
     public static void makeGetRequest(final Context context,
-                                      String url,
+                                      String path,
                                       HashMap<String,String> params,
                                       JSONObject body,
                                       final ResponseListener listener,
                                       final int requestCode) {
-        makeRequest(context, Request.Method.GET, url, params, body, listener, requestCode);
+        makeRequest(context, Request.Method.GET, path, params, body, listener, requestCode);
     }
 
     public static void makePutRequest(final Context context,
-                                      String url,
+                                      String path,
                                       JSONObject body,
                                       final ResponseListener listener,
                                       final int requestCode) {
-        makeRequest(context, Request.Method.PUT, url, null, body, listener, requestCode);
+        makeRequest(context, Request.Method.PUT, path, null, body, listener, requestCode);
     }
 
     public static void makeDeleteRequest(final Context context,
-                                         String url,
+                                         String path,
                                          JSONObject body,
                                          final ResponseListener listener,
                                          final int requestCode) {
-        makeRequest(context, Request.Method.DELETE, url, null, body, listener, requestCode);
+        makeRequest(context, Request.Method.DELETE, path, null, body, listener, requestCode);
     }
 
     private static void makeRequest(final Context context,
                                     int method,
-                                    String url,
+                                    String path,
                                     HashMap<String, String> params,
                                     JSONObject body,
                                     final ResponseListener listener,
                                     final int requestCode) {
 
+        String url = Constants.API_BASE_URL.concat(path);
         if(params!=null)
             url = url.concat("?".concat(ArrayUtils.mapToQueryString(params)));
 

--- a/app/src/main/java/com/att/m2x/android/network/JsonRequest.java
+++ b/app/src/main/java/com/att/m2x/android/network/JsonRequest.java
@@ -31,55 +31,54 @@ public class JsonRequest {
     final static ApiV2Response apiResponse = new ApiV2Response();
 
     public static void makePostRequest(final Context context,
-                                       String path,
+                                       String url,
                                        JSONObject body,
                                        final ResponseListener listener,
                                        final int requestCode) {
-        makeRequest(context, Request.Method.POST, path, null, body, listener, requestCode);
+        makeRequest(context, Request.Method.POST, url, null, body, listener, requestCode);
     }
 
     public static void makeGetRequest(final Context context,
-                                      String path,
+                                      String url,
                                       HashMap<String,String> params,
                                       final ResponseListener listener,
                                       final int requestCode) {
-        makeRequest(context, Request.Method.GET, path, params, null, listener, requestCode);
+        makeRequest(context, Request.Method.GET, url, params, null, listener, requestCode);
     }
 
     public static void makeGetRequest(final Context context,
-                                      String path,
+                                      String url,
                                       HashMap<String,String> params,
                                       JSONObject body,
                                       final ResponseListener listener,
                                       final int requestCode) {
-        makeRequest(context, Request.Method.GET, path, params, body, listener, requestCode);
+        makeRequest(context, Request.Method.GET, url, params, body, listener, requestCode);
     }
 
     public static void makePutRequest(final Context context,
-                                      String path,
+                                      String url,
                                       JSONObject body,
                                       final ResponseListener listener,
                                       final int requestCode) {
-        makeRequest(context, Request.Method.PUT, path, null, body, listener, requestCode);
+        makeRequest(context, Request.Method.PUT, url, null, body, listener, requestCode);
     }
 
     public static void makeDeleteRequest(final Context context,
-                                         String path,
+                                         String url,
                                          JSONObject body,
                                          final ResponseListener listener,
                                          final int requestCode) {
-        makeRequest(context, Request.Method.DELETE, path, null, body, listener, requestCode);
+        makeRequest(context, Request.Method.DELETE, url, null, body, listener, requestCode);
     }
 
     private static void makeRequest(final Context context,
                                     int method,
-                                    String path,
+                                    String url,
                                     HashMap<String, String> params,
                                     JSONObject body,
                                     final ResponseListener listener,
                                     final int requestCode) {
 
-        String url = Constants.API_BASE_URL.concat(path);
         if(params!=null)
             url = url.concat("?".concat(ArrayUtils.mapToQueryString(params)));
 


### PR DESCRIPTION
See [Ruby library implementation](https://github.com/attm2x/m2x-ruby/commit/044b282afd614e87e68b7516353d65cbe3c79ab0) for reference.

Add support for the following endpoints:

Device Metadata:
* https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata
* https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata
* https://m2x.att.com/developer/documentation/v2/device#Read-Device-Metadata-Field
* https://m2x.att.com/developer/documentation/v2/device#Update-Device-Metadata-Field

Distribution Metadata:
* https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata
* https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata
* https://m2x.att.com/developer/documentation/v2/distribution#Read-Distribution-Metadata-Field
* https://m2x.att.com/developer/documentation/v2/distribution#Update-Distribution-Metadata-Field